### PR TITLE
bookmark実装＋ScaffoldMessengerの追加

### DIFF
--- a/lib/constant.dart
+++ b/lib/constant.dart
@@ -123,6 +123,32 @@ class UserRepost {
     }
   }
 
+  Future<void> bookmark() async {
+    if (postBookmarked) {
+      throw Exception('Post $postNumber is already bookmarked.');
+    } else {
+      final response = await httpPost('bookmark/$postNumber/', null, jwt: true);
+      if (response['bookmarked']) {
+        postBookmarked = true;
+      } else {
+        throw Exception('Post $postNumber is already bookmarked in backend.');
+      }
+    }
+  }
+
+  Future<void> unbookmark() async {
+    if (!postBookmarked) {
+      throw Exception('Post $postNumber is already unbookmarked.');
+    } else {
+      final response = await httpPost('bookmark/$postNumber/', null, jwt: true);
+      if (!response['bookmarked']) {
+        postBookmarked = false;
+      } else {
+        throw Exception('Post $postNumber is already unbookmarked in backend.');
+      }
+    }
+  }
+
   factory UserRepost.fromJson(Map<String, dynamic> json) {
     List<Progress> progressList = [];
     List<String> progressTextList = [];


### PR DESCRIPTION
# Bookmarkの実装

- 基本的にはlikeと同様
- 下からメッセージを表示するためにScaffoldMessengerの追加（以下Chatgptより）

`メッセージを表示するために、SnackBarを使用してフィードバックメッセージを表示することができます。SnackBarは一時的なメッセージを表示するためのウィジェットで、画面の下部に表示され、一定時間が経過すると自動的に消えます。`